### PR TITLE
Create teletext travel offer layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Monster Travel Teletext</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="teletext-screen">
+    <section class="teletext-status-bar">
+      <div class="status-code">P265/19</div>
+      <div class="status-channel">Teletext</div>
+      <div class="status-page">265</div>
+      <div class="status-date">Dec14</div>
+      <div class="status-time">12:59:20</div>
+    </section>
+
+    <header class="teletext-header">
+      <div class="decorations">
+        <div class="sun"></div>
+        <div class="palm left-palm"></div>
+        <div class="palm right-palm"></div>
+        <div class="wave left-wave"></div>
+        <div class="wave right-wave"></div>
+      </div>
+      <p class="brand">MONSTER TRAVEL</p>
+      <h1 class="headline">ALL INCLUSIVE</h1>
+    </header>
+
+    <section class="teletext-table">
+      <div class="table-header">
+        <span class="col destination">ALGARVE</span>
+        <span class="col price">£175</span>
+        <span class="col destination">G.CANARIA</span>
+        <span class="col price">£169</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">MAJORCA</span>
+        <span class="col price">£199</span>
+        <span class="col destination">TENERIFE</span>
+        <span class="col price">£165</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">TUNISIA</span>
+        <span class="col price">£149</span>
+        <span class="col destination">F'VENTURA</span>
+        <span class="col price">£185</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">TURKEY</span>
+        <span class="col price">£199</span>
+        <span class="col destination">LANZAROTE</span>
+        <span class="col price">£179</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">BENIDORM</span>
+        <span class="col price">£139</span>
+        <span class="col destination">CORFU</span>
+        <span class="col price">£159</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">GREECE</span>
+        <span class="col price">£209</span>
+        <span class="col destination">HURGHADA</span>
+        <span class="col price">£209</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">CYPRUS</span>
+        <span class="col price">£245</span>
+        <span class="col destination">4xSHARM</span>
+        <span class="col price">£309</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">4xMALTA</span>
+        <span class="col price">£215</span>
+        <span class="col destination">4xTABA</span>
+        <span class="col price">£379</span>
+      </div>
+      <div class="table-row">
+        <span class="col destination">4xC.D.SOL</span>
+        <span class="col price">£235</span>
+        <span class="col destination">CARIBBEAN</span>
+        <span class="col price">£259</span>
+      </div>
+    </section>
+
+    <section class="teletext-footer">
+      <p class="footer-info">
+        ABTA L3442. AGTALOT. A1=3HR, PRICE FROM CCC.2. 5%, DCC1%, NO BOOKING FEE, DISC INCL
+      </p>
+      <div class="footer-callout">
+        <span class="call-prefix">CALL US FREE FOR MORE MONSTER DEALS</span>
+        <span class="call-number">0800 280 2560</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,244 @@
+:root {
+  --teletext-blue: #0000e6;
+  --teletext-yellow: #ffff00;
+  --teletext-magenta: #ff28d1;
+  --teletext-cyan: #00ffe6;
+  --teletext-green: #00ff38;
+  --teletext-red: #ff2700;
+  --teletext-white: #ffffff;
+  --teletext-black: #000000;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--teletext-black);
+  color: var(--teletext-white);
+  font-family: "VT323", monospace;
+  letter-spacing: 0.04em;
+}
+
+.teletext-screen {
+  width: min(860px, 95vw);
+  background: var(--teletext-blue);
+  border: 16px solid var(--teletext-black);
+  outline: 8px solid var(--teletext-green);
+  padding: 16px 22px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  box-shadow: 0 0 0 8px var(--teletext-black);
+}
+
+.teletext-status-bar {
+  display: grid;
+  grid-template-columns: repeat(5, max-content);
+  justify-content: space-between;
+  align-items: center;
+  background: var(--teletext-black);
+  padding: 4px 10px 2px;
+  font-size: clamp(20px, 4vw, 28px);
+  text-transform: uppercase;
+}
+
+.teletext-header {
+  text-align: center;
+  padding-top: 8px;
+  padding-bottom: 10px;
+  border-bottom: 6px solid var(--teletext-black);
+  position: relative;
+}
+
+.teletext-header .decorations {
+  position: absolute;
+  inset: -40px 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 90px;
+  pointer-events: none;
+}
+
+.teletext-header .sun {
+  width: 120px;
+  height: 80px;
+  border-radius: 50% / 55%;
+  background: linear-gradient(to bottom, #ffec61 0%, #ff9a00 60%, #ff5e00 100%);
+  box-shadow: 0 0 0 8px var(--teletext-magenta);
+}
+
+.palm {
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 120px solid var(--teletext-magenta);
+  position: relative;
+}
+
+.palm::before,
+.palm::after {
+  content: "";
+  position: absolute;
+  width: 64px;
+  height: 22px;
+  background: var(--teletext-magenta);
+  top: -10px;
+  border-radius: 12px;
+}
+
+.palm::before {
+  transform: rotate(-25deg);
+  left: -58px;
+}
+
+.palm::after {
+  transform: rotate(25deg);
+  right: -58px;
+}
+
+.left-palm {
+  transform: rotate(8deg);
+}
+
+.right-palm {
+  transform: scaleX(-1) rotate(8deg);
+}
+
+.wave {
+  width: 90px;
+  height: 14px;
+  border-radius: 14px;
+  background: var(--teletext-cyan);
+  position: absolute;
+  bottom: -34px;
+}
+
+.left-wave {
+  left: 120px;
+}
+
+.right-wave {
+  right: 120px;
+}
+
+.brand {
+  margin: 40px 0 4px;
+  color: var(--teletext-cyan);
+  font-size: clamp(28px, 6vw, 42px);
+  letter-spacing: 0.12em;
+}
+
+.headline {
+  margin: 0;
+  color: var(--teletext-yellow);
+  font-size: clamp(52px, 10vw, 80px);
+  letter-spacing: 0.2em;
+}
+
+.teletext-table {
+  display: grid;
+  gap: 10px;
+  font-size: clamp(26px, 5vw, 36px);
+}
+
+.teletext-table .table-header {
+  background: var(--teletext-black);
+  color: var(--teletext-green);
+  padding: 4px 10px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  column-gap: 18px;
+}
+
+.teletext-table .table-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  column-gap: 18px;
+  padding: 4px 10px;
+  background: var(--teletext-blue);
+  border-bottom: 2px solid var(--teletext-black);
+}
+
+.teletext-table .table-row:nth-child(odd) {
+  background: #0000cc;
+}
+
+.teletext-table .price {
+  text-align: right;
+  color: var(--teletext-yellow);
+}
+
+.teletext-table .destination {
+  color: var(--teletext-white);
+}
+
+.teletext-footer {
+  background: var(--teletext-black);
+  padding: 10px 12px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-transform: uppercase;
+}
+
+.footer-info {
+  margin: 0;
+  color: var(--teletext-green);
+  font-size: clamp(18px, 3.5vw, 24px);
+  letter-spacing: 0.1em;
+}
+
+.footer-callout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  font-size: clamp(32px, 7vw, 60px);
+}
+
+.footer-callout .call-prefix {
+  color: var(--teletext-white);
+  letter-spacing: 0.16em;
+}
+
+.footer-callout .call-number {
+  color: var(--teletext-yellow);
+  font-size: clamp(44px, 9vw, 74px);
+  letter-spacing: 0.1em;
+}
+
+@media (max-width: 640px) {
+  .teletext-status-bar {
+    grid-template-columns: repeat(5, 1fr);
+    text-align: center;
+    row-gap: 4px;
+  }
+
+  .teletext-header .decorations {
+    inset: -60px 0 auto;
+    gap: 60px;
+  }
+
+  .wave {
+    display: none;
+  }
+
+  .teletext-table .table-header,
+  .teletext-table .table-row {
+    grid-template-columns: repeat(2, 1fr);
+    text-align: left;
+  }
+
+  .teletext-table .price {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index.html mockup for the Monster Travel teletext screen
- implement retro styling in styles.css including palm, sun, and pricing table decorations

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc4a27a490832c8cf22edb7bbda1ff