### PR TITLE
Add animated split-flap board and interactive deal details

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
+  <script src="script.js" defer></script>
 </head>
 <body>
   <main class="teletext-screen">
@@ -33,58 +34,28 @@
 
     <section class="teletext-table">
       <div class="table-header">
-        <span class="col destination">ALGARVE</span>
-        <span class="col price">£175</span>
-        <span class="col destination">G.CANARIA</span>
-        <span class="col price">£169</span>
+        <span class="col flight">FLIGHT</span>
+        <span class="col destination">DESTINATION</span>
+        <span class="col depart">DEPART</span>
+        <span class="col status">STATUS</span>
       </div>
-      <div class="table-row">
-        <span class="col destination">MAJORCA</span>
-        <span class="col price">£199</span>
-        <span class="col destination">TENERIFE</span>
-        <span class="col price">£165</span>
-      </div>
-      <div class="table-row">
-        <span class="col destination">TUNISIA</span>
-        <span class="col price">£149</span>
-        <span class="col destination">F'VENTURA</span>
-        <span class="col price">£185</span>
-      </div>
-      <div class="table-row">
-        <span class="col destination">TURKEY</span>
-        <span class="col price">£199</span>
-        <span class="col destination">LANZAROTE</span>
-        <span class="col price">£179</span>
-      </div>
-      <div class="table-row">
-        <span class="col destination">BENIDORM</span>
-        <span class="col price">£139</span>
-        <span class="col destination">CORFU</span>
-        <span class="col price">£159</span>
-      </div>
-      <div class="table-row">
-        <span class="col destination">GREECE</span>
-        <span class="col price">£209</span>
-        <span class="col destination">HURGHADA</span>
-        <span class="col price">£209</span>
-      </div>
-      <div class="table-row">
-        <span class="col destination">CYPRUS</span>
-        <span class="col price">£245</span>
-        <span class="col destination">4xSHARM</span>
-        <span class="col price">£309</span>
-      </div>
-      <div class="table-row">
-        <span class="col destination">4xMALTA</span>
-        <span class="col price">£215</span>
-        <span class="col destination">4xTABA</span>
-        <span class="col price">£379</span>
-      </div>
-      <div class="table-row">
-        <span class="col destination">4xC.D.SOL</span>
-        <span class="col price">£235</span>
-        <span class="col destination">CARIBBEAN</span>
-        <span class="col price">£259</span>
+      <div class="departures-list" data-board-list role="list" aria-live="polite"></div>
+    </section>
+
+    <section class="selection-panel" data-selection-panel aria-live="polite">
+      <h2 class="selection-title">Подробности тура</h2>
+      <p class="selection-placeholder" data-selection-placeholder>
+        Выберите предложение, чтобы узнать детали пакета Monster Travel.
+      </p>
+      <div class="selection-details" data-selection-details hidden>
+        <p class="selection-destination" data-selection-destination></p>
+        <p class="selection-meta">
+          <span data-selection-duration></span>
+          <span aria-hidden="true">·</span>
+          <span data-selection-gate></span>
+        </p>
+        <p class="selection-price" data-selection-price></p>
+        <p class="selection-description" data-selection-description></p>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -1,0 +1,374 @@
+const flights = [
+  {
+    flight: "MT101",
+    destination: "ALGARVE",
+    depart: "06:20",
+    status: "BOARDING",
+    gate: "GATE A3",
+    duration: "7 НОЧЕЙ · ALL INCLUSIVE",
+    price: "£175",
+    description: "Семейный курорт с песчаными пляжами Албуфейры и бесплатным трансфером от Monster Travel.",
+  },
+  {
+    flight: "MT212",
+    destination: "G.CANARIA",
+    depart: "07:05",
+    status: "FINAL CALL",
+    gate: "GATE B1",
+    duration: "7 НОЧЕЙ · ALL INCLUSIVE",
+    price: "£169",
+    description: "Тёплые канарские вечера, бассейн с подогревом и эксклюзивные экскурсии по дюнам Маспаломаса.",
+  },
+  {
+    flight: "MT305",
+    destination: "MAJORCA",
+    depart: "08:45",
+    status: "ON TIME",
+    gate: "GATE C5",
+    duration: "10 НОЧЕЙ · HALF BOARD",
+    price: "£199",
+    description: "Пальма-де-Майорка, живая набережная, ночные прогулки и приветственный коктейль в отеле 4★.",
+  },
+  {
+    flight: "MT328",
+    destination: "TENERIFE",
+    depart: "09:15",
+    status: "ON TIME",
+    gate: "GATE A8",
+    duration: "7 НОЧЕЙ · ALL INCLUSIVE",
+    price: "£165",
+    description: "Лунный пейзаж Тейде, парк Loro и гарантированное солнце весь отпуск.",
+  },
+  {
+    flight: "MT410",
+    destination: "TUNISIA",
+    depart: "10:20",
+    status: "BOARDING",
+    gate: "GATE D2",
+    duration: "7 НОЧЕЙ · FULL BOARD",
+    price: "£149",
+    description: "Хаммамет и Сусс с восточным базаром, уроками танца и частным пляжем.",
+  },
+  {
+    flight: "MT512",
+    destination: "F'VENTURA",
+    depart: "11:05",
+    status: "DELAYED",
+    gate: "GATE B6",
+    duration: "14 НОЧЕЙ · ALL INCLUSIVE",
+    price: "£185",
+    description: "Просторные пляжи, серфинг для начинающих и бесплатный детский клуб на две недели.",
+  },
+  {
+    flight: "MT604",
+    destination: "LANZAROTE",
+    depart: "12:40",
+    status: "GO TO GATE",
+    gate: "GATE C4",
+    duration: "7 НОЧЕЙ · ALL INCLUSIVE",
+    price: "£179",
+    description: "Вулканические пейзажи Тиманфайи, дегустация местных вин и бассейн с морской водой.",
+  },
+  {
+    flight: "MT720",
+    destination: "BENIDORM",
+    depart: "13:35",
+    status: "ON TIME",
+    gate: "GATE A1",
+    duration: "7 НОЧЕЙ · ROOM ONLY",
+    price: "£139",
+    description: "Городские огни Бенидорма, небоскрёбы, пляж Леванте и бесплатный бар на крыше.",
+  },
+  {
+    flight: "MT842",
+    destination: "CORFU",
+    depart: "14:10",
+    status: "NEW GATE",
+    gate: "GATE F3",
+    duration: "7 НОЧЕЙ · HALF BOARD",
+    price: "£159",
+    description: "Изумрудные бухты, греческие таверны и экскурсия на лодке к Палеокастрице.",
+  },
+  {
+    flight: "MT915",
+    destination: "HURGHADA",
+    depart: "15:55",
+    status: "ON TIME",
+    gate: "GATE E2",
+    duration: "7 НОЧЕЙ · ALL INCLUSIVE",
+    price: "£209",
+    description: "Красное море, дайвинг-сафари, гигантские рифы и аквапарк на территории отеля.",
+  },
+  {
+    flight: "MT990",
+    destination: "CYPRUS",
+    depart: "16:30",
+    status: "BOARDING",
+    gate: "GATE D7",
+    duration: "14 НОЧЕЙ · HALF BOARD",
+    price: "£245",
+    description: "Айя-Напа, древний курион и поездка на закат к скале Афродиты.",
+  },
+  {
+    flight: "MT104",
+    destination: "CARIBBEAN",
+    depart: "18:10",
+    status: "ON TIME",
+    gate: "GATE H2",
+    duration: "10 НОЧЕЙ · ULTRA ALL INCLUSIVE",
+    price: "£259",
+    description: "Карибские вечера с живой музыкой, катамаран и экскурс по ромовым плантациям.",
+  },
+];
+
+const boardContainer = document.querySelector('[data-board-list]');
+const selectionPanel = document.querySelector('[data-selection-panel]');
+const selectionPlaceholder = selectionPanel?.querySelector('[data-selection-placeholder]');
+const selectionDetails = selectionPanel?.querySelector('[data-selection-details]');
+const selectionDestination = selectionPanel?.querySelector('[data-selection-destination]');
+const selectionDuration = selectionPanel?.querySelector('[data-selection-duration]');
+const selectionGate = selectionPanel?.querySelector('[data-selection-gate]');
+const selectionPrice = selectionPanel?.querySelector('[data-selection-price]');
+const selectionDescription = selectionPanel?.querySelector('[data-selection-description]');
+const statusTime = document.querySelector('.status-time');
+const statusDate = document.querySelector('.status-date');
+
+const visibleRowCount = Math.min(8, flights.length);
+const boardRows = [];
+let activeRow = null;
+let cyclePointer = visibleRowCount % flights.length;
+let rotationIndex = 0;
+
+function updateClock() {
+  const now = new Date();
+  const timeString = now
+    .toLocaleTimeString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    .replace(/\./g, ':');
+  if (statusTime) {
+    statusTime.textContent = timeString;
+  }
+  if (statusDate) {
+    const month = now
+      .toLocaleDateString('en-GB', { month: 'short' })
+      .replace('.', '')
+      .toUpperCase();
+    const day = String(now.getDate()).padStart(2, '0');
+    statusDate.textContent = `${month}${day}`;
+  }
+}
+
+function createBoardCell(initialValue) {
+  const cell = document.createElement('span');
+  cell.className = 'board-cell';
+
+  const topFace = document.createElement('span');
+  topFace.className = 'board-cell-face board-cell-face--upper';
+
+  const bottomFace = document.createElement('span');
+  bottomFace.className = 'board-cell-face board-cell-face--lower';
+
+  const flipUpper = document.createElement('span');
+  flipUpper.className = 'board-cell-flip board-cell-flip--upper';
+
+  const flipLower = document.createElement('span');
+  flipLower.className = 'board-cell-flip board-cell-flip--lower';
+
+  const srOnly = document.createElement('span');
+  srOnly.className = 'sr-only board-cell-text';
+
+  cell.append(topFace, bottomFace, flipUpper, flipLower, srOnly);
+
+  function setInstant(value) {
+    const displayValue = value || '\u00A0';
+    topFace.textContent = displayValue;
+    bottomFace.textContent = displayValue;
+    srOnly.textContent = displayValue;
+    cell.dataset.currentValue = displayValue;
+  }
+
+  function setAnimated(value) {
+    const nextValue = value || '\u00A0';
+    const currentValue = cell.dataset.currentValue;
+    if (currentValue === nextValue) {
+      return;
+    }
+
+    if (cell.classList.contains('is-flipping')) {
+      cell.classList.remove('is-flipping');
+    }
+
+    bottomFace.textContent = nextValue;
+    flipUpper.textContent = currentValue || '\u00A0';
+    flipLower.textContent = nextValue;
+
+    void cell.offsetWidth;
+    cell.classList.add('is-flipping');
+
+    flipLower.addEventListener(
+      'animationend',
+      () => {
+        cell.classList.remove('is-flipping');
+        topFace.textContent = nextValue;
+        bottomFace.textContent = nextValue;
+        srOnly.textContent = nextValue;
+        flipUpper.textContent = '';
+        flipLower.textContent = '';
+        cell.dataset.currentValue = nextValue;
+      },
+      { once: true }
+    );
+  }
+
+  setInstant(initialValue);
+
+  return {
+    element: cell,
+    setInstant,
+    setValue: setAnimated,
+  };
+}
+
+function createBoardRow(flight) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'table-row board-row';
+  button.setAttribute('role', 'listitem');
+
+  const columns = [
+    { key: 'flight', className: 'flight' },
+    { key: 'destination', className: 'destination' },
+    { key: 'depart', className: 'depart' },
+    { key: 'status', className: 'status' },
+  ];
+
+  const cells = columns.map((column) => {
+    const cell = createBoardCell(flight[column.key]);
+    cell.element.classList.add('col', column.className);
+    button.appendChild(cell.element);
+    return cell;
+  });
+
+  function updateAriaLabel(data) {
+    button.setAttribute(
+      'aria-label',
+      `${data.flight} → ${data.destination}, вылет ${data.depart}, статус ${data.status}`
+    );
+  }
+
+  button.addEventListener('click', () => {
+    setActiveRow(rowApi);
+  });
+
+  const rowApi = {
+    button,
+    cells,
+    flight,
+    setFlight(nextFlight, { animate } = { animate: true }) {
+      this.flight = nextFlight;
+      columns.forEach((column, index) => {
+        const value = nextFlight[column.key];
+        if (animate) {
+          cells[index].setValue(value);
+        } else {
+          cells[index].setInstant(value);
+        }
+      });
+      updateAriaLabel(nextFlight);
+      button.dataset.flight = nextFlight.flight;
+      button.dataset.destination = nextFlight.destination;
+      button.dataset.price = nextFlight.price;
+      button.dataset.status = nextFlight.status
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-');
+    },
+  };
+
+  rowApi.setFlight(flight, { animate: false });
+
+  return rowApi;
+}
+
+function populateBoard() {
+  if (!boardContainer) {
+    return;
+  }
+
+  for (let i = 0; i < visibleRowCount; i += 1) {
+    const flight = flights[i % flights.length];
+    const row = createBoardRow(flight);
+    boardRows.push(row);
+    boardContainer.appendChild(row.button);
+  }
+}
+
+function rotateBoard() {
+  if (flights.length <= visibleRowCount) {
+    return;
+  }
+
+  const rowIndex = rotationIndex % visibleRowCount;
+  const nextFlight = flights[cyclePointer % flights.length];
+  cyclePointer = (cyclePointer + 1) % flights.length;
+  rotationIndex += 1;
+
+  const row = boardRows[rowIndex];
+  row.setFlight(nextFlight, { animate: true });
+
+  if (activeRow === row) {
+    updateSelectionPanel(nextFlight);
+  }
+}
+
+function setActiveRow(row) {
+  if (activeRow) {
+    activeRow.button.classList.remove('is-active');
+  }
+  activeRow = row;
+  activeRow.button.classList.add('is-active');
+  updateSelectionPanel(row.flight);
+}
+
+function updateSelectionPanel(flight) {
+  if (!selectionPanel || !selectionDetails || !selectionPlaceholder) {
+    return;
+  }
+
+  selectionPlaceholder.hidden = true;
+  selectionDetails.hidden = false;
+
+  if (selectionDestination) {
+    selectionDestination.textContent = `${flight.destination} · ${flight.flight}`;
+  }
+  if (selectionDuration) {
+    selectionDuration.textContent = flight.duration;
+  }
+  if (selectionGate) {
+    selectionGate.textContent = flight.gate;
+  }
+  if (selectionPrice) {
+    selectionPrice.textContent = flight.price;
+  }
+  if (selectionDescription) {
+    selectionDescription.textContent = flight.description;
+  }
+}
+
+function autoSelectInitialRow() {
+  if (boardRows.length === 0) {
+    return;
+  }
+  setActiveRow(boardRows[0]);
+}
+
+updateClock();
+setInterval(updateClock, 1000);
+populateBoard();
+autoSelectInitialRow();
+
+if (flights.length > visibleRowCount) {
+  setInterval(rotateBoard, 4000);
+}

--- a/styles.css
+++ b/styles.css
@@ -146,39 +146,272 @@ body {
 
 .teletext-table {
   display: grid;
-  gap: 10px;
-  font-size: clamp(26px, 5vw, 36px);
+  gap: 14px;
+  font-size: clamp(24px, 4.5vw, 34px);
 }
 
 .teletext-table .table-header {
   background: var(--teletext-black);
   color: var(--teletext-green);
-  padding: 4px 10px;
+  padding: 6px 14px;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  column-gap: 18px;
+  grid-template-columns: minmax(110px, 1.1fr) minmax(200px, 2.2fr) minmax(120px, 1.1fr) minmax(140px, 1.2fr);
+  column-gap: 14px;
+  letter-spacing: 0.08em;
 }
 
-.teletext-table .table-row {
+.departures-list {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  column-gap: 18px;
-  padding: 4px 10px;
+  gap: 12px;
+}
+
+.teletext-table .col {
+  display: flex;
+  align-items: center;
+}
+
+.teletext-table .table-header .col {
+  color: var(--teletext-green);
+}
+
+.board-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 1.1fr) minmax(200px, 2.2fr) minmax(120px, 1.1fr) minmax(140px, 1.2fr);
+  column-gap: 14px;
+  padding: 4px 6px;
+  border: none;
   background: var(--teletext-blue);
   border-bottom: 2px solid var(--teletext-black);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  width: 100%;
+  appearance: none;
 }
 
-.teletext-table .table-row:nth-child(odd) {
+.board-row:nth-child(even) {
   background: #0000cc;
 }
 
-.teletext-table .price {
-  text-align: right;
-  color: var(--teletext-yellow);
+.board-row .flight .board-cell {
+  --board-cell-color: var(--teletext-cyan);
 }
 
-.teletext-table .destination {
+.board-row .destination .board-cell {
+  --board-cell-color: var(--teletext-white);
+}
+
+.board-row .depart .board-cell {
+  --board-cell-color: var(--teletext-yellow);
+}
+
+.board-row .status .board-cell {
+  --board-cell-color: var(--teletext-green);
+}
+
+.board-row[data-status*='delayed'] .status .board-cell {
+  --board-cell-color: var(--teletext-red);
+}
+
+.board-row[data-status*='final-call'] .status .board-cell {
+  --board-cell-color: var(--teletext-yellow);
+}
+
+.board-row[data-status*='go-to-gate'] .status .board-cell {
+  --board-cell-color: var(--teletext-cyan);
+}
+
+.board-row[data-status*='new-gate'] .status .board-cell {
+  --board-cell-color: var(--teletext-magenta);
+}
+
+.board-row:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 0 rgba(0, 0, 0, 0.35);
+}
+
+.board-row.is-active {
+  outline: 3px solid var(--teletext-yellow);
+  outline-offset: 4px;
+  box-shadow: 0 8px 0 rgba(0, 0, 0, 0.4);
+}
+
+.board-row:focus-visible {
+  outline: 4px solid var(--teletext-cyan);
+  outline-offset: 4px;
+}
+
+.board-cell {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  background: linear-gradient(to bottom, #14144a 0%, #090932 100%);
+  border: 2px solid #050527;
+  border-radius: 6px;
+  min-height: clamp(46px, 7vw, 64px);
+  padding: 0 12px;
+  color: var(--board-cell-color, var(--teletext-yellow));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.35);
+  perspective: 800px;
+  overflow: hidden;
+}
+
+.board-cell-face,
+.board-cell-flip {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  backface-visibility: hidden;
+  font-size: inherit;
+  font-weight: inherit;
+  overflow: hidden;
+}
+
+.board-cell-face {
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.35));
+}
+
+.board-cell-face--upper {
+  top: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.6);
+}
+
+.board-cell-face--lower {
+  bottom: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.board-cell-flip {
+  display: none;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.18), rgba(0, 0, 0, 0.5));
+}
+
+.board-cell-flip--upper {
+  top: 0;
+  transform-origin: bottom;
+}
+
+.board-cell-flip--lower {
+  bottom: 0;
+  transform-origin: top;
+  transform: rotateX(90deg);
+}
+
+.board-cell.is-flipping .board-cell-face--upper {
+  opacity: 0;
+}
+
+.board-cell.is-flipping .board-cell-flip {
+  display: flex;
+}
+
+.board-cell.is-flipping .board-cell-flip--upper {
+  animation: flap-upper 0.6s cubic-bezier(0.37, 0, 0.63, 1) forwards;
+}
+
+.board-cell.is-flipping .board-cell-flip--lower {
+  animation: flap-lower 0.6s cubic-bezier(0.37, 0, 0.63, 1) forwards;
+}
+
+@keyframes flap-upper {
+  0% {
+    transform: rotateX(0deg);
+  }
+  100% {
+    transform: rotateX(-90deg);
+  }
+}
+
+@keyframes flap-lower {
+  0% {
+    transform: rotateX(90deg);
+  }
+  100% {
+    transform: rotateX(0deg);
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.selection-panel {
+  background: var(--teletext-black);
+  border: 4px solid var(--teletext-green);
+  padding: 18px 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-transform: uppercase;
+}
+
+.selection-title {
+  margin: 0;
+  color: var(--teletext-cyan);
+  font-size: clamp(26px, 5vw, 36px);
+  letter-spacing: 0.14em;
+}
+
+.selection-placeholder {
+  margin: 0;
+  color: var(--teletext-green);
+  font-size: clamp(20px, 4vw, 26px);
+  letter-spacing: 0.08em;
+}
+
+.selection-details {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.selection-destination {
+  margin: 0;
+  color: var(--teletext-yellow);
+  font-size: clamp(32px, 7vw, 48px);
+  letter-spacing: 0.18em;
+}
+
+.selection-meta {
+  margin: 0;
+  display: flex;
+  gap: 8px;
+  align-items: center;
   color: var(--teletext-white);
+  font-size: clamp(20px, 4vw, 26px);
+  letter-spacing: 0.08em;
+}
+
+.selection-price {
+  margin: 0;
+  color: var(--teletext-magenta);
+  font-size: clamp(34px, 8vw, 56px);
+  letter-spacing: 0.12em;
+}
+
+.selection-description {
+  margin: 0;
+  color: var(--teletext-white);
+  font-size: clamp(18px, 3.5vw, 24px);
+  line-height: 1.2;
 }
 
 .teletext-footer {
@@ -233,12 +466,24 @@ body {
   }
 
   .teletext-table .table-header,
-  .teletext-table .table-row {
+  .board-row {
     grid-template-columns: repeat(2, 1fr);
-    text-align: left;
+    row-gap: 8px;
   }
 
-  .teletext-table .price {
-    text-align: left;
+  .teletext-table .table-header .flight,
+  .board-row .flight {
+    grid-column: 1 / -1;
+  }
+
+  .board-cell {
+    min-height: clamp(38px, 12vw, 50px);
+    padding: 0 8px;
+  }
+
+  .selection-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the static price grid with an animated split-flap departures board that cycles Monster Travel offers
- add an interactive selection panel that reacts to row clicks and surfaces detailed package information
- introduce supporting styles and script logic for the clickable teletext prototype, including a live status clock

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc4c94a18c832c810b086749493df2